### PR TITLE
fix: properly resolve install root

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,8 @@ fn main() -> Result<()> {
     } else {
         None
     };
-    let cargo_install_root = cargo_install_root.unwrap_or(cargo_root);
+    let cargo_install_root =
+        cargo_install_root.map_or(cargo_root, |root| home::home_dir().unwrap().join(root));
 
     let crates_toml = cargo_install_root.join(".crates.toml");
     if !crates_toml.exists() {


### PR DESCRIPTION
Before this, the install root from config.toml was used relative to the current working directory. Now we join the path with the users home directory, and invoking the subcommand from a none-home directory works now.